### PR TITLE
Fix for "to" selector

### DIFF
--- a/gmaily/gmaily.py
+++ b/gmaily/gmaily.py
@@ -174,7 +174,7 @@ class SearchQuery:
         return self
 
     def to(self, string):
-        self._criterias.extend(["TO", to])
+        self._criterias.extend(["TO", string])
         return self
 
     def unanswered(self):


### PR DESCRIPTION
Very useful if an account has aliases to filter with `.to()`. But this is broken, this is a fix